### PR TITLE
Set url to lowercase for ExcludeProtocols

### DIFF
--- a/maintenance/updateExternalLinks.php
+++ b/maintenance/updateExternalLinks.php
@@ -44,7 +44,7 @@ class UpdateExternalLinks extends Maintenance {
 
 			$urlexp = explode( ':', $url );
 
-			if ( isset( $urlexp[0] ) && in_array( strtolower($urlexp[0]), (array)$config->get( 'RottenLinksExcludeProtocols' ) ) ) {
+			if ( isset( $urlexp[0] ) && in_array( strtolower( $urlexp[0] ), (array)$config->get( 'RottenLinksExcludeProtocols' ) ) ) {
 				continue;
 			}
 

--- a/maintenance/updateExternalLinks.php
+++ b/maintenance/updateExternalLinks.php
@@ -44,7 +44,7 @@ class UpdateExternalLinks extends Maintenance {
 
 			$urlexp = explode( ':', $url );
 
-			if ( isset( $urlexp[0] ) && in_array( $urlexp[0], (array)$config->get( 'RottenLinksExcludeProtocols' ) ) ) {
+			if ( isset( $urlexp[0] ) && in_array( strtolower($urlexp[0]), (array)$config->get( 'RottenLinksExcludeProtocols' ) ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
mailto links were not being excluded for us because some are set with a capital "M" in our mediawiki.
setting url variable to lowercase