### PR TITLE
Fix sql patches for case when rottenlinks.rl_externallink is primary key

### DIFF
--- a/sql/patches/20210215.sql
+++ b/sql/patches/20210215.sql
@@ -1,8 +1,5 @@
 BEGIN;
 
-ALTER TABLE /*$wgDBprefix*/rottenlinks
-    MODIFY COLUMN rl_externallink BLOB NOT NULL;
-
 CREATE INDEX /*i*/rl_externallink ON /*_*/rottenlinks (rl_externallink(50));
 CREATE INDEX /*i*/rl_respcode ON /*_*/rottenlinks (rl_respcode);
 CREATE INDEX /*i*/rl_pageusage ON /*_*/rottenlinks (rl_pageusage(50));

--- a/sql/patches/patch-add-rl_id.sql
+++ b/sql/patches/patch-add-rl_id.sql
@@ -1,2 +1,30 @@
-ALTER TABLE /*$wgDBprefix*/rottenlinks
+BEGIN;
+
+delimiter //
+
+CREATE PROCEDURE removePrimaryKey() BEGIN
+    IF EXISTS(
+            select constraint_name
+            from information_schema.table_constraints
+            where table_name = REPLACE( '/*_*/rottenlinks', '`', '' )
+              and table_schema = database()
+              and constraint_name = 'PRIMARY'
+        )
+    THEN
+        ALTER TABLE /*_*/rottenlinks DROP PRIMARY KEY;
+    END IF;
+END;
+//
+
+delimiter ;
+
+CALL removePrimaryKey();
+DROP PROCEDURE removePrimaryKey;
+
+ALTER TABLE /*_*/rottenlinks
+    MODIFY COLUMN rl_externallink BLOB NOT NULL;
+
+ALTER TABLE /*_*/rottenlinks
     ADD COLUMN `rl_id` INT UNSIGNED AUTO_INCREMENT PRIMARY KEY FIRST;
+
+COMMIT;


### PR DESCRIPTION
In some cases rottenlinks can have rl_externallink as a primary key, but in
some cases it is not. In the first case the database updater throws
SQL exception (it can't create primary key if it already exists)
the removePrimaryKey stored procedure removes primary key in the
rottenlinks table if it exists.