### PR TITLE
Make Protocols Lowercase Before Sending Request

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 == ChangeLog for RottenLinks ==
 
+=== 1.0.14 (05-06-2021) ===
+* Make protocols lowercase before making request
+
 === 1.0.13 (13-05-2021) ===
 * Use HttpRequestFactory
 

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "RottenLinks",
-	"version": "1.0.13",
+	"version": "1.0.14",
 	"author": [
 		"John Lewis"
 	],

--- a/includes/RottenLinks.php
+++ b/includes/RottenLinks.php
@@ -15,7 +15,7 @@ class RottenLinks {
 		$urltouse = $proto . $site;
 		
 		$request = $services->getHttpRequestFactory()->create(
-			$urltouse ), [ 
+			$urltouse, [ 
 				'method' => 'HEAD', // return headers only
 				'timeout' => $config->get( 'RottenLinksCurlTimeout' ),
 				'userAgent' => 'RottenLinks, MediaWiki extension (https://github.com/miraheze/RottenLinks), running on ' . $config->get( 'Server' )

--- a/includes/RottenLinks.php
+++ b/includes/RottenLinks.php
@@ -7,9 +7,15 @@ class RottenLinks {
 		$services = MediaWikiServices::getInstance();
 
 		$config = $services->getConfigFactory()->makeConfig( 'rottenlinks' );
-
+		
+		// Make the protocol lowercase
+		$urlexp = explode( '://', $url);
+		$proto = strtolower( $urlexp[0] ) . '://';
+		$site = $urlexp[1]; 
+		$urltouse = $proto . $site;
+		
 		$request = $services->getHttpRequestFactory()->create(
-			strtolower( $url ), [ 
+			$urltouse ), [ 
 				'method' => 'HEAD', // return headers only
 				'timeout' => $config->get( 'RottenLinksCurlTimeout' ),
 				'userAgent' => 'RottenLinks, MediaWiki extension (https://github.com/miraheze/RottenLinks), running on ' . $config->get( 'Server' )

--- a/includes/RottenLinks.php
+++ b/includes/RottenLinks.php
@@ -9,7 +9,7 @@ class RottenLinks {
 		$config = $services->getConfigFactory()->makeConfig( 'rottenlinks' );
 
 		$request = $services->getHttpRequestFactory()->create(
-			$url, [ 
+			strtolower( $url ), [ 
 				'method' => 'HEAD', // return headers only
 				'timeout' => $config->get( 'RottenLinksCurlTimeout' ),
 				'userAgent' => 'RottenLinks, MediaWiki extension (https://github.com/miraheze/RottenLinks), running on ' . $config->get( 'Server' )

--- a/includes/RottenLinks.php
+++ b/includes/RottenLinks.php
@@ -12,10 +12,10 @@ class RottenLinks {
 		$urlexp = explode( '://', $url);
 		$proto = strtolower( $urlexp[0] ) . '://';
 		$site = $urlexp[1]; 
-		$urltouse = $proto . $site;
+		$urlToUse = $proto . $site;
 		
 		$request = $services->getHttpRequestFactory()->create(
-			$urltouse, [ 
+			$urlToUse, [ 
 				'method' => 'HEAD', // return headers only
 				'timeout' => $config->get( 'RottenLinksCurlTimeout' ),
 				'userAgent' => 'RottenLinks, MediaWiki extension (https://github.com/miraheze/RottenLinks), running on ' . $config->get( 'Server' )


### PR DESCRIPTION
People sometimes forget to use lowercase characters in the protocol which makes RottenLinks grumpy. This simple change makes it so that the URL is made lowercase before sending the request to check a URL. See https://snapwiki.miraheze.org/wiki/Special:RottenLinks?showBad=1&limit=50 where ``Https://GitHub.com`` has been detected to be a "rotten" URL.