### PR TITLE
Use MultiHttpClient

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 == ChangeLog for RottenLinks ==
 
-=== 1.0.17 (12-08-2021) ===
+=== 1.0.17 (13-08-2021) ===
 * Use MultiHttpClient
 * Lower minimum required MediaWiki version to 1.35.3
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 == ChangeLog for RottenLinks ==
 
+=== 1.0.17 (12-08-2021) ===
+* Use MultiHttpClient
+* Lower minimum required MediaWiki version to 1.35.3
+
 === 1.0.16 (15-06-2021) ===
 * Fix sql patches for case when rottenlinks.rl_externallink is primary key
 

--- a/extension.json
+++ b/extension.json
@@ -38,7 +38,7 @@
 		"RottenLinksBadCodes": {
 			"description": "Holds a list of HTTP codes that are considered bad. (array)",
 			"public": true,
-			"value": [ "0", "400", "401", "403", "404", "405", "502", "503", "504", "999" ]
+			"value": [ "0", "400", "401", "403", "404", "405", "502", "503", "504" ]
 		},
 		"RottenLinksCurlTimeout": {
 			"description": "Sets the timeout for cURL in seconds. (integer)",

--- a/extension.json
+++ b/extension.json
@@ -38,7 +38,7 @@
 		"RottenLinksBadCodes": {
 			"description": "Holds a list of HTTP codes that are considered bad. (array)",
 			"public": true,
-			"value": [ "0", "400", "401", "403", "404", "405", "502", "503", "504" ]
+			"value": [ "0", "400", "401", "403", "404", "405", "502", "503", "504", "999" ]
 		},
 		"RottenLinksCurlTimeout": {
 			"description": "Sets the timeout for cURL in seconds. (integer)",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "RottenLinks",
-	"version": "1.0.16",
+	"version": "1.0.17",
 	"author": [
 		"John Lewis",
 		"Universal Omega"
@@ -10,7 +10,7 @@
 	"url": "https://github.com/miraheze/RottenLinks",
 	"type": "specialpage",
 	"requires": {
-		"MediaWiki": ">= 1.36.0"
+		"MediaWiki": ">= 1.35.3"
 	},
 	"SpecialPages": {
 		"RottenLinks": "SpecialRottenLinks"

--- a/includes/RottenLinks.php
+++ b/includes/RottenLinks.php
@@ -14,15 +14,18 @@ class RottenLinks {
 		$site = $urlexp[1]; 
 		$urlToUse = $proto . $site;
 		
-		$request = $services->getHttpRequestFactory()->create(
-			$urlToUse, [ 
+		$request = $services->getHttpRequestFactory()->createMultiClient()
+			->run( [
+				'url' => $urlToUse,
 				'method' => 'HEAD', // return headers only
-				'timeout' => $config->get( 'RottenLinksCurlTimeout' ),
-				'userAgent' => 'RottenLinks, MediaWiki extension (https://github.com/miraheze/RottenLinks), running on ' . $config->get( 'Server' )
-			],
-			__METHOD__
-		)->execute();
+				'headers' => [ 
+					'user-agent' => 'RottenLinks, MediaWiki extension (https://github.com/miraheze/RottenLinks), running on ' . $config->get( 'Server' )
+				]
+			], [
+				'reqTimeout' => $config->get( 'RottenLinksCurlTimeout' )
+			]
+		);
 
-		return (int)$request->getStatusValue()->getValue();
+		return (int)$request['code'];
 	}
 }

--- a/includes/RottenLinks.php
+++ b/includes/RottenLinks.php
@@ -7,13 +7,13 @@ class RottenLinks {
 		$services = MediaWikiServices::getInstance();
 
 		$config = $services->getConfigFactory()->makeConfig( 'rottenlinks' );
-		
+
 		// Make the protocol lowercase
-		$urlexp = explode( '://', $url);
+		$urlexp = explode( '://', $url );
 		$proto = strtolower( $urlexp[0] ) . '://';
 		$site = $urlexp[1]; 
 		$urlToUse = $proto . $site;
-		
+
 		$request = $services->getHttpRequestFactory()->createMultiClient()
 			->run( [
 				'url' => $urlToUse,

--- a/includes/RottenLinksPager.php
+++ b/includes/RottenLinksPager.php
@@ -39,7 +39,7 @@ class RottenLinksPager extends TablePager {
 				$respCode = (int)$row->rl_respcode;
 				$colour = ( in_array( $respCode, $this->config->get( 'RottenLinksBadCodes' ) ) ) ? "#8B0000" : "#008000";
 				$formatted = ( $respCode != 0 )
-					? HTML::element( 'font', [ 'color' => $colour ], HttpStatus::getMessage( $respCode ) )
+					? HTML::element( 'font', [ 'color' => $colour ], HttpStatus::getMessage( $respCode ) ?? $respCode )
 					: HTML::element( 'font', [ 'color' => '#8B0000' ], 'No Response' );
 				break;
 			case 'rl_pageusage':

--- a/includes/RottenLinksPager.php
+++ b/includes/RottenLinksPager.php
@@ -39,7 +39,7 @@ class RottenLinksPager extends TablePager {
 				$respCode = (int)$row->rl_respcode;
 				$colour = ( in_array( $respCode, $this->config->get( 'RottenLinksBadCodes' ) ) ) ? "#8B0000" : "#008000";
 				$formatted = ( $respCode != 0 )
-					? HTML::element( 'font', [ 'color' => $colour ], HttpStatus::getMessage( $respCode ) ?? $respCode )
+					? HTML::element( 'font', [ 'color' => $colour ], HttpStatus::getMessage( $respCode ) ?? "HTTP: ${respCode}" )
 					: HTML::element( 'font', [ 'color' => '#8B0000' ], 'No Response' );
 				break;
 			case 'rl_pageusage':

--- a/includes/SpecialRottenLinks.php
+++ b/includes/SpecialRottenLinks.php
@@ -94,7 +94,7 @@ class SpecialRottenLinks extends SpecialPage {
 
 			$statDescriptor[$respCode] = [
 				'type' => 'info',
-				'label' => "HTTP: ${respCode} " . ( $respCode != 0 ) ? HttpStatus::getMessage( $respCode ) : 'No Response',
+				'label' => "HTTP: ${respCode} " . ( $respCode != 0 ) ? ( HttpStatus::getMessage( $respCode ) ?? $respCode ) : 'No Response',
 				'default' => $count,
 				'section' => 'statistics'
 			];

--- a/includes/SpecialRottenLinks.php
+++ b/includes/SpecialRottenLinks.php
@@ -94,7 +94,7 @@ class SpecialRottenLinks extends SpecialPage {
 
 			$statDescriptor[$respCode] = [
 				'type' => 'info',
-				'label' => "HTTP: ${respCode} " . ( $respCode != 0 ? ( HttpStatus::getMessage( $respCode ) ?? $respCode ) : 'No Response' ),
+				'label' => "HTTP: ${respCode} " . ( $respCode != 0 ? HttpStatus::getMessage( $respCode ) : 'No Response' ),
 				'default' => $count,
 				'section' => 'statistics'
 			];

--- a/includes/SpecialRottenLinks.php
+++ b/includes/SpecialRottenLinks.php
@@ -94,7 +94,7 @@ class SpecialRottenLinks extends SpecialPage {
 
 			$statDescriptor[$respCode] = [
 				'type' => 'info',
-				'label' => "HTTP: ${respCode} " . ( $respCode != 0 ) ? ( HttpStatus::getMessage( $respCode ) ?? $respCode ) : 'No Response',
+				'label' => "HTTP: ${respCode} " . ( $respCode != (int)0 ) ? ( HttpStatus::getMessage( $respCode ) ?? $respCode ) : 'No Response',
 				'default' => $count,
 				'section' => 'statistics'
 			];

--- a/includes/SpecialRottenLinks.php
+++ b/includes/SpecialRottenLinks.php
@@ -94,7 +94,7 @@ class SpecialRottenLinks extends SpecialPage {
 
 			$statDescriptor[$respCode] = [
 				'type' => 'info',
-				'label' => "HTTP: ${respCode} " . $respCode != 0 ? ( HttpStatus::getMessage( $respCode ) ?? $respCode ) : 'No Response',
+				'label' => "HTTP: ${respCode} " . ( $respCode != 0 ? ( HttpStatus::getMessage( $respCode ) ?? $respCode ) : 'No Response' ),
 				'default' => $count,
 				'section' => 'statistics'
 			];

--- a/includes/SpecialRottenLinks.php
+++ b/includes/SpecialRottenLinks.php
@@ -94,7 +94,7 @@ class SpecialRottenLinks extends SpecialPage {
 
 			$statDescriptor[$respCode] = [
 				'type' => 'info',
-				'label' => "HTTP: ${respCode} " . ( $respCode != (int)0 ) ? ( HttpStatus::getMessage( $respCode ) ?? $respCode ) : 'No Response',
+				'label' => "HTTP: ${respCode} " . $respCode != 0 ? ( HttpStatus::getMessage( $respCode ) ?? $respCode ) : 'No Response',
 				'default' => $count,
 				'section' => 'statistics'
 			];


### PR DESCRIPTION
Fixes [T7788](https://phabricator.miraheze.org/T7788).

This converts it to use MultiHttpClient, which should convert it back to former behavior (before c5a8212) to use cURL (as an option) instead of GuzzleHttpClient, which doesn't work for some status codes.

Also lowers the minimum required MediaWiki version to 1.35.3 since it would still work there, since `DB_PRIMARY` was backported to 1.35.3.

```bash
curl -I --url https://de.linkedin.com/company/linkedin --http1.1 | grep HTTP

HTTP/1.1 999 Request denied
```

Suggests this will properly work, but still unverified.

Adding;
```json
"platform": {
	"ext-curl": "*"
}
```
To the requirements might be a good idea since GuzzleHttpClient has issues, which without cURL would still be used. But for now that's probably not necessary.