### PR TITLE
pull status message directly from response not HttpStatus

### DIFF
--- a/includes/RottenLinks.php
+++ b/includes/RottenLinks.php
@@ -26,6 +26,6 @@ class RottenLinks {
 			]
 		);
 
-		return (int)$request['code'];
+		return $request;
 	}
 }

--- a/includes/RottenLinks.php
+++ b/includes/RottenLinks.php
@@ -14,6 +14,9 @@ class RottenLinks {
 		$site = $urlexp[1]; 
 		$urlToUse = $proto . $site;
 
+		// force cURL to use HTTP_VERSION_1_1 to get status messages
+		curl_setopt( curl_init(), CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1 );
+
 		$request = $services->getHttpRequestFactory()->createMultiClient()
 			->run( [
 				'url' => $urlToUse,

--- a/includes/RottenLinksPager.php
+++ b/includes/RottenLinksPager.php
@@ -37,9 +37,10 @@ class RottenLinksPager extends TablePager {
 				break;
 			case 'rl_respcode':
 				$respCode = (int)$row->rl_respcode;
+
 				$colour = ( in_array( $respCode, $this->config->get( 'RottenLinksBadCodes' ) ) ) ? "#8B0000" : "#008000";
 				$formatted = ( $respCode != 0 )
-					? HTML::element( 'font', [ 'color' => $colour ], HttpStatus::getMessage( $respCode ) )
+					? HTML::element( 'font', [ 'color' => $colour ], RottenLinks::getResponse( $row->rl_externallink )['reason'] )
 					: HTML::element( 'font', [ 'color' => '#8B0000' ], 'No Response' );
 				break;
 			case 'rl_pageusage':

--- a/maintenance/updateExternalLinks.php
+++ b/maintenance/updateExternalLinks.php
@@ -54,7 +54,7 @@ class UpdateExternalLinks extends Maintenance {
 				continue;
 			}
 
-			$resp = RottenLinks::getResponse( $url );
+			$resp = (int)( RottenLinks::getResponse( $url )['code'] );
 			$pagecount = count( $pages );
 
 			$dbw->insert( 'rottenlinks',


### PR DESCRIPTION
In the long run using `RottenLinks::getResponse()` like this, could completely remove the need for the rottenlinks database table, and the maintenance script, keeping everything constantly up-to-date through use of the `externallinks` table directly.