### PR TITLE
don't allow sorting by page usage per T8920

### DIFF
--- a/includes/RottenLinksPager.php
+++ b/includes/RottenLinksPager.php
@@ -79,6 +79,10 @@ class RottenLinksPager extends TablePager {
 	}
 
 	public function isFieldSortable( $name ) {
-		return true;
+		if ( $name === 'rl_pageusage' ) {
+			return false;
+		} else {
+			return true;
+		}
 	}
 }


### PR DESCRIPTION
Per T8920, sorting by page usage doesn't work so in order to avoid confusion we should disallow it