### PR TITLE
Redesign RottenLinks to not depend on a maintenance script

### DIFF
--- a/.github/workflows/mediawiki-tests.yml
+++ b/.github/workflows/mediawiki-tests.yml
@@ -12,17 +12,31 @@ jobs:
     strategy:
       matrix:
         include:
-          # Latest Old MediaWiki stable - PHP 7.4 
-          - mw: 'REL1_39'
+          # Latest MediaWiki stable - PHP 7.4
+          - mw: 'REL1_40'
             php: 7.4
             php-docker: 74
             composer-test: true
             experimental: false
 
-          # Latest MediaWiki stable - PHP 7.4 
+          # Latest MediaWiki stable - PHP 8.2
           - mw: 'REL1_40'
+            php: 8.2
+            php-docker: 82
+            composer-test: true
+            experimental: false
+
+          # Latest MediaWiki stable - PHP 7.4
+          - mw: 'REL1_41'
             php: 7.4
             php-docker: 74
+            composer-test: true
+            experimental: false
+
+          # Latest MediaWiki stable - PHP 8.2
+          - mw: 'REL1_41'
+            php: 8.2
+            php-docker: 82
             composer-test: true
             experimental: false
 

--- a/.github/workflows/mediawiki-tests.yml
+++ b/.github/workflows/mediawiki-tests.yml
@@ -31,14 +31,14 @@ jobs:
             php: 7.4
             php-docker: 74
             composer-test: true
-            experimental: false
+            experimental: true
 
           # Latest MediaWiki stable - PHP 8.2
           - mw: 'REL1_41'
             php: 8.2
             php-docker: 82
             composer-test: true
-            experimental: false
+            experimental: true
 
           # Latest MediaWiki master - PHP 7.4
           - mw: 'master'

--- a/.github/workflows/mediawiki-tests.yml
+++ b/.github/workflows/mediawiki-tests.yml
@@ -19,26 +19,12 @@ jobs:
             composer-test: true
             experimental: false
 
-          # Latest MediaWiki stable - PHP 8.2
-          - mw: 'REL1_40'
-            php: 8.2
-            php-docker: 82
-            composer-test: true
-            experimental: false
-
           # Latest MediaWiki stable - PHP 7.4
           - mw: 'REL1_41'
             php: 7.4
             php-docker: 74
             composer-test: true
-            experimental: true
-
-          # Latest MediaWiki stable - PHP 8.2
-          - mw: 'REL1_41'
-            php: 8.2
-            php-docker: 82
-            composer-test: true
-            experimental: true
+            experimental: false
 
           # Latest MediaWiki master - PHP 7.4
           - mw: 'master'

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -3,6 +3,7 @@
 $cfg = require __DIR__ . '/../vendor/mediawiki/mediawiki-phan-config/src/config.php';
 
 $cfg['suppress_issue_types'] = [
+	'PhanAccessMethodInternal',
 	'SecurityCheck-LikelyFalsePositive'
 ];
 

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -4,6 +4,7 @@ $cfg = require __DIR__ . '/../vendor/mediawiki/mediawiki-phan-config/src/config.
 
 $cfg['suppress_issue_types'] = [
 	'PhanAccessMethodInternal',
+	'PhanUndeclaredStaticMethod',
 	'SecurityCheck-LikelyFalsePositive'
 ];
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   migrateExternallinks maintenance script and to set
   wgExternalLinksSchemaMigrationStage to SCHEMA_COMPAT_WRITE_BOTH | SCHEMA_COMPAT_READ_NEW
   or SCHEMA_COMPAT_WRITE_NEW | SCHEMA_COMPAT_READ_NEW.
+* Add support for MediaWiki 1.41.
+* Fix some deprecated warnings in php 8.2.
 
 ### 1.0.20 (10-01-2023)
 * SpecialRottenLinks: replace usage of deprecated wfGetDB()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   Config is removed under MW 1.41+.
 * Add support for MediaWiki 1.41.
 * Fix some deprecated warnings in php 8.2.
+* Remove showing lastRun and runTime as these are no longer needed.
+  They didn't work very well to begin with.
+* Adds additional messages to qqq.json.
 
 ### 1.0.20 (10-01-2023)
 * SpecialRottenLinks: replace usage of deprecated wfGetDB()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
   storing it ourselfs. Saves space and reduces complexity in getting it.
 * Requires MediaWiki 1.40 or higher and to have migrated externallinks using
   migrateExternallinks maintenance script and to set
-  wgExternalLinksSchemaMigrationStage to SCHEMA_COMPAT_WRITE_BOTH | SCHEMA_COMPAT_READ_NEW
-  or SCHEMA_COMPAT_WRITE_NEW | SCHEMA_COMPAT_READ_NEW.
+  wgExternalLinksSchemaMigrationStage to SCHEMA_COMPAT_WRITE_BOTH | SCHEMA_COMPAT_READ_OLD.
+  Config is removed under MW 1.41+.
 * Add support for MediaWiki 1.41.
 * Fix some deprecated warnings in php 8.2.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 ## ChangeLog for RottenLinks
 
-### 1.1.0 (DD-MM-2023)
-* Redesign RottenLinks slightly to not depend on a maintenance script
+### 2.0.0 (DD-MM-2023)
+* Redesign RottenLinks to not depend on a maintenance script
 * Changes how to count page usage on RottenLinks special page.
   We directly gather this from externallinks table rather then
   storing it ourselfs. Saves space and reduces complexity in getting it.
+* Requires MediaWiki 1.40 or higher and to have migrated externallinks using
+  migrateExternallinks maintenance script and to set
+  wgExternalLinksSchemaMigrationStage to SCHEMA_COMPAT_WRITE_BOTH | SCHEMA_COMPAT_READ_NEW
+  or SCHEMA_COMPAT_WRITE_NEW | SCHEMA_COMPAT_READ_NEW.
 
 ### 1.0.20 (10-01-2023)
 * SpecialRottenLinks: replace usage of deprecated wfGetDB()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 2.0.0 (DD-MM-2023)
 * Redesign RottenLinks to not depend on a maintenance script
-* Changes how to count page usage on RottenLinks special page.
+* Changes how we count page usage on RottenLinks special page.
   We directly gather this from externallinks table rather then
   storing it ourselfs. Saves space and reduces complexity in getting it.
 * Requires MediaWiki 1.40 or higher and to have migrated externallinks using

--- a/extension.json
+++ b/extension.json
@@ -10,7 +10,7 @@
 	"url": "https://github.com/miraheze/RottenLinks",
 	"type": "specialpage",
 	"requires": {
-		"MediaWiki": ">= 1.35.3"
+		"MediaWiki": ">= 1.40.0"
 	},
 	"SpecialPages": {
 		"RottenLinks": "SpecialRottenLinks"

--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,8 @@
 	"version": "2.0.0",
 	"author": [
 		"John Lewis",
-		"Universal Omega"
+		"Universal Omega",
+		"Paladox"
 	],
 	"descriptionmsg": "rottenlinks-desc",
 	"license-name": "GPL-3.0-or-later",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "RottenLinks",
-	"version": "1.1.0",
+	"version": "2.0.0",
 	"author": [
 		"John Lewis",
 		"Universal Omega"

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -10,8 +10,6 @@
 	"rottenlinks-table-external": "Externer Link",
 	"rottenlinks-table-response": "HTTP-Antwort",
 	"rottenlinks-table-usage": "Seitenanzahl",
-	"rottenlinks-rundate": "Ausführungsdatum",
-	"rottenlinks-runtime": "Ausführungszeitraum",
 	"rottenlinks-showbad": "Lediglich fehlerhafte Links anzeigen",
 	"rottenlinks-statistics": "Statistiken zu den Links",
 	"rottenlinks-stats": "Statistiken anzeigen"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -11,8 +11,6 @@
 	"rottenlinks-table-external": "External Link",
 	"rottenlinks-table-response": "HTTP Response",
 	"rottenlinks-table-usage": "Page Usage",
-	"rottenlinks-rundate": "Script run date",
-	"rottenlinks-runtime": "Script execution time",
 	"rottenlinks-showbad": "Show rotten links only",
 	"rottenlinks-statistics": "Rotten Link Statistics",
 	"rottenlinks-stats": "Show link statistics"

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -10,8 +10,6 @@
 	"rottenlinks-table-external": "Ulkoinen linkki",
 	"rottenlinks-table-response": "HTTP-vastaus",
 	"rottenlinks-table-usage": "Käyttö sivuilla",
-	"rottenlinks-rundate": "Skriptin suorituspäivä",
-	"rottenlinks-runtime": "Skriptin suoritusaika",
 	"rottenlinks-showbad": "Näytä vain huonot linkit",
 	"rottenlinks-statistics": "Ulkoisten linkkien toimivuustilasto",
 	"rottenlinks-stats": "Näytä linkkitilastot"

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -11,8 +11,6 @@
 	"rottenlinks-table-external": "Lien externe",
 	"rottenlinks-table-response": "Réponse HTTP",
 	"rottenlinks-table-usage": "Utilisation de la page",
-	"rottenlinks-rundate": "Date d’exécution du script",
-	"rottenlinks-runtime": "Durée d’exécution du script",
 	"rottenlinks-showbad": "Afficher seulement les liens corrompus",
 	"rottenlinks-statistics": "Statistiques des liens corrompus",
 	"rottenlinks-stats": "Afficher les statistiques des liens"

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -10,8 +10,6 @@
 	"rottenlinks-table-external": "קישור חיצוני",
 	"rottenlinks-table-response": "תגובת HTTP",
 	"rottenlinks-table-usage": "שימוש בדף",
-	"rottenlinks-rundate": "תאריך הרצת הסקריפט",
-	"rottenlinks-runtime": "זמן ביצוע הסקריפט",
 	"rottenlinks-showbad": "הצג קישורים מתים בלבד",
 	"rottenlinks-statistics": "סטטיסטיקות קישורים מתים",
 	"rottenlinks-stats": "הצגת סטטיסטיקות קישורים"

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -5,6 +5,5 @@
 		]
 	},
 	"rottenlinks": "Külső linkek állapota",
-	"rottenlinks-table-response": "HTTP-válasz",
-	"rottenlinks-rundate": "A szkript legutóbbi futtatása"
+	"rottenlinks-table-response": "HTTP-válasz"
 }

--- a/i18n/ia.json
+++ b/i18n/ia.json
@@ -10,8 +10,6 @@
 	"rottenlinks-table-external": "Ligamine externe",
 	"rottenlinks-table-response": "Responsa HTTP",
 	"rottenlinks-table-usage": "Uso del pagina",
-	"rottenlinks-rundate": "Data de execution del script",
-	"rottenlinks-runtime": "Durata de execution del script",
 	"rottenlinks-showbad": "Monstrar solmente le ligamines putrite",
 	"rottenlinks-statistics": "Statisticas de ligamines putrite",
 	"rottenlinks-stats": "Monstrar statisticas de ligamines"

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -13,8 +13,6 @@
 	"rottenlinks-table-external": "外部リンク",
 	"rottenlinks-table-response": "HTTPレスポンス",
 	"rottenlinks-table-usage": "ページの使用状況",
-	"rottenlinks-rundate": "スクリプトが実行されて日時",
-	"rottenlinks-runtime": "スクリプトの実行時間",
 	"rottenlinks-showbad": "腐ったリンクのみを表示",
 	"rottenlinks-statistics": "腐ったリンクの統計",
 	"rottenlinks-stats": "リンクの統計を表示"

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -10,8 +10,6 @@
 	"rottenlinks-table-external": "Išorinė nuoroda",
 	"rottenlinks-table-response": "HTTP atsakymas",
 	"rottenlinks-table-usage": "Puslapio naudojimas",
-	"rottenlinks-rundate": "Kodo vykdymo data",
-	"rottenlinks-runtime": "Kodo vykdymo trukmė",
 	"rottenlinks-showbad": "Rodyti tik sugedusias nuorodas",
 	"rottenlinks-statistics": "Sugedusių nuorodų statistika",
 	"rottenlinks-stats": "Rodyti nuorodų statistiką"

--- a/i18n/mk.json
+++ b/i18n/mk.json
@@ -10,8 +10,6 @@
 	"rottenlinks-table-external": "Надворешна врска",
 	"rottenlinks-table-response": "HTTP-одговор",
 	"rottenlinks-table-usage": "Употреба на страницата",
-	"rottenlinks-rundate": "Датум на пуштање",
-	"rottenlinks-runtime": "Време на исполнување",
 	"rottenlinks-showbad": "Прикажувај само расипани врски",
 	"rottenlinks-statistics": "Статистика за расипани врски",
 	"rottenlinks-stats": "Дај статистика за врски"

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -10,8 +10,6 @@
 	"rottenlinks-table-external": "Externe koppeling",
 	"rottenlinks-table-response": "HTTP-antwoord",
 	"rottenlinks-table-usage": "Paginagebruik",
-	"rottenlinks-rundate": "Uitvoeringsdatum script",
-	"rottenlinks-runtime": "Uitvoeringstijd script",
 	"rottenlinks-showbad": "Alleen rotte links tonen",
 	"rottenlinks-statistics": "Statistieken over rotte links",
 	"rottenlinks-stats": "Linkstatistieken weergeven"

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -11,8 +11,6 @@
 	"rottenlinks-table-external": "Link zewnętrzny",
 	"rottenlinks-table-response": "Odpowiedź HTTP",
 	"rottenlinks-table-usage": "Użycie na stronach",
-	"rottenlinks-rundate": "Data uruchomienia skryptu",
-	"rottenlinks-runtime": "Czas wykonania skryptu",
 	"rottenlinks-showbad": "Pokaż tylko zgniłe linki",
 	"rottenlinks-statistics": "Statystyki zgniłych linków",
 	"rottenlinks-stats": "Pokaż statystyki linków"

--- a/i18n/pt-br.json
+++ b/i18n/pt-br.json
@@ -10,8 +10,6 @@
 	"rottenlinks-table-external": "Link externo",
 	"rottenlinks-table-response": "Resposta HTTP",
 	"rottenlinks-table-usage": "Uso de página",
-	"rottenlinks-rundate": "Data de execução do script",
-	"rottenlinks-runtime": "Tempo de execução do script",
 	"rottenlinks-showbad": "Mostrar somente links quebrados",
 	"rottenlinks-statistics": "Estatísticas de link quebrado",
 	"rottenlinks-stats": "Mostrar estatísticas do link"

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -10,8 +10,6 @@
 	"rottenlinks-table-external": "Hiperligação externa",
 	"rottenlinks-table-response": "Resposta HTTP",
 	"rottenlinks-table-usage": "Utilização da página",
-	"rottenlinks-rundate": "Data de execução do ''script''",
-	"rottenlinks-runtime": "Tempo de execução do ''script''",
 	"rottenlinks-showbad": "Mostrar só as hiperligações corrompidas",
 	"rottenlinks-statistics": "Estatísticas de hiperligações corrompidas",
 	"rottenlinks-stats": "Mostrar estatísticas das hiperligações"

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -2,13 +2,16 @@
 	"@metadata": {
 		"authors": [
 			"John Lewis",
-			"Kghbln"
+			"Kghbln",
+			""Universal Omega"
 		]
 	},
-	"rottenlinks": "This is the title of Special:RottenLinks as well as the label of the link pointing to it on Special:SpecialPages",
-	"rottenlinks-desc": "This is the extension's despription on Special:Verion",
+	"rottenlinks": "{{doc-special}}",
+	"rottenlinks-desc": "{{desc|name=RottenLinks|url=https://github.com/miraheze/RottenLinks}}",
 	"rottenlinks-table-external": "This is the label of a tabel header on Special:RottenLinks",
 	"rottenlinks-table-response": "This is the label of a tabel header on Special:RottenLinks",
 	"rottenlinks-table-usage": "This is the label of a tabel header on Special:RottenLinks",
-	"rottenlinks-showbad": "This is the text describing a checkbox on Special:RottenLinks"
+	"rottenlinks-showbad": "This is the text describing a checkbox on Special:RottenLinks",
+	"rottenlinks-statistics": "This is the text of a form section on Special:RottenLinks",
+	"rottenlinks-stats": "This is the text describing a checkbox on Special:RottenLinks"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -3,7 +3,7 @@
 		"authors": [
 			"John Lewis",
 			"Kghbln",
-			""Universal Omega"
+			"Universal Omega"
 		]
 	},
 	"rottenlinks": "{{doc-special}}",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -10,8 +10,6 @@
 	"rottenlinks-table-external": "Внешняя ссылка",
 	"rottenlinks-table-response": "HTTP-ответ",
 	"rottenlinks-table-usage": "Использование страницы",
-	"rottenlinks-rundate": "Дата выполнения скрипта",
-	"rottenlinks-runtime": "Время выполнения скрипта",
 	"rottenlinks-showbad": "Отобразить только гнилые ссылки",
 	"rottenlinks-statistics": "Статистика гнилых ссылок",
 	"rottenlinks-stats": "Отобразить статистику ссылок"

--- a/i18n/sh-cyrl.json
+++ b/i18n/sh-cyrl.json
@@ -10,8 +10,6 @@
 	"rottenlinks-table-external": "Вањски линк",
 	"rottenlinks-table-response": "HTTP-одговор",
 	"rottenlinks-table-usage": "Употреба странице",
-	"rottenlinks-rundate": "Датум покретања скрипте",
-	"rottenlinks-runtime": "Вријеме извршења скрипте",
 	"rottenlinks-showbad": "Прикажи само покварене линкове",
 	"rottenlinks-statistics": "Статистика покварених линкова",
 	"rottenlinks-stats": "Дај статистику линкова"

--- a/i18n/sh-latn.json
+++ b/i18n/sh-latn.json
@@ -11,8 +11,6 @@
 	"rottenlinks-table-external": "Vanjski link",
 	"rottenlinks-table-response": "HTTP-odgovor",
 	"rottenlinks-table-usage": "Upotreba stranice",
-	"rottenlinks-rundate": "Datum pokretanja skripte",
-	"rottenlinks-runtime": "Vrijeme izvršenja skripte",
 	"rottenlinks-showbad": "Prikaži samo pokvarene linkove",
 	"rottenlinks-statistics": "Statistika pokvarenih linkova",
 	"rottenlinks-stats": "Daj statistiku linkova"

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -10,8 +10,6 @@
 	"rottenlinks-table-external": "Zunanja povezava",
 	"rottenlinks-table-response": "HTTP-odgovor",
 	"rottenlinks-table-usage": "Uporaba strani",
-	"rottenlinks-rundate": "Datum izvedbe skripta",
-	"rottenlinks-runtime": "Čas izvedbe skripta",
 	"rottenlinks-showbad": "Pokaži samo nedelujoče povezave",
 	"rottenlinks-statistics": "Statistika nedelujočih povezav",
 	"rottenlinks-stats": "Prikaži statistiko povezav"

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -10,8 +10,6 @@
 	"rottenlinks-table-external": "Extern länk",
 	"rottenlinks-table-response": "HTTP-respons",
 	"rottenlinks-table-usage": "Sidanvändning",
-	"rottenlinks-rundate": "Skriptkörningsdatum",
-	"rottenlinks-runtime": "Skriptuförningstid",
 	"rottenlinks-showbad": "Visa bara döda länkar",
 	"rottenlinks-statistics": "Statistik över döda länkar",
 	"rottenlinks-stats": "Visa länkstatistik"

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -11,8 +11,6 @@
 	"rottenlinks-table-external": "Dış Bağlantı",
 	"rottenlinks-table-response": "HTTP Yanıtı",
 	"rottenlinks-table-usage": "Sayfa Kullanımı",
-	"rottenlinks-rundate": "Komut dosyası çalıştırma tarihi",
-	"rottenlinks-runtime": "Komut dosyası yürütme süresi",
 	"rottenlinks-showbad": "Yalnızca bozuk bağlantıları göster",
 	"rottenlinks-statistics": "Bozuk Bağlantı İstatistikleri",
 	"rottenlinks-stats": "Bağlantı istatistiklerini göster"

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -10,8 +10,6 @@
 	"rottenlinks-table-external": "外部链接",
 	"rottenlinks-table-response": "HTTP响应",
 	"rottenlinks-table-usage": "页面使用情况",
-	"rottenlinks-rundate": "脚本运行日期",
-	"rottenlinks-runtime": "脚本执行时间",
 	"rottenlinks-showbad": "仅显示错误链接",
 	"rottenlinks-statistics": "错误链接统计信息",
 	"rottenlinks-stats": "显示链接统计信息"

--- a/i18n/zh-hant.json
+++ b/i18n/zh-hant.json
@@ -10,8 +10,6 @@
 	"rottenlinks-table-external": "外部連結",
 	"rottenlinks-table-response": "HTTP 回應",
 	"rottenlinks-table-usage": "頁面使用情況",
-	"rottenlinks-rundate": "腳本運作日期",
-	"rottenlinks-runtime": "腳本執行時間",
 	"rottenlinks-showbad": "只顯示損壞連結",
 	"rottenlinks-statistics": "損壞連結統計",
 	"rottenlinks-stats": "顯示連結統計"

--- a/includes/RottenLinksHooks.php
+++ b/includes/RottenLinksHooks.php
@@ -9,7 +9,7 @@ class RottenLinksHooks {
 	 * @param LinksUpdate $linksUpdate
 	 * @param mixed $ticket
 	 */
-	public function onLinksUpdateComplete( $linksUpdate, $ticket ) {
+	public static function onLinksUpdateComplete( $linksUpdate, $ticket ) {
 		$addedExternalLinks = $linksUpdate->getAddedExternalLinks();
 		$removedExternalLinks = $linksUpdate->getRemovedExternalLinks();
 

--- a/includes/RottenLinksHooks.php
+++ b/includes/RottenLinksHooks.php
@@ -36,5 +36,8 @@ class RottenLinksHooks {
 
 		$updater->addExtensionIndex( 'rottenlinks', 'rl_externallink',
 			__DIR__ . '/../sql/patches/20210215.sql' );
+
+		$updater->dropExtensionField( 'rottenlinks', 'rl_pageusage',
+			__DIR__ . '/../sql/patches/patch-drop-rl_pageusage.sql' );
 	}
 }

--- a/includes/RottenLinksJob.php
+++ b/includes/RottenLinksJob.php
@@ -16,7 +16,7 @@ class RottenLinksJob extends Job implements GenericParameterJob {
 		parent::__construct( 'RottenLinksJob', $params );
 
 		$this->addedExternalLinks = $params['addedExternalLinks'] ?? [];
-		$this->removedExternalLinks $params['removedExternalLinks'] ?? [];
+		$this->removedExternalLinks = $params['removedExternalLinks'] ?? [];
 	}
 
 	public function run() {

--- a/includes/RottenLinksJob.php
+++ b/includes/RottenLinksJob.php
@@ -1,7 +1,5 @@
 <?php
 
-use GenericParameterJob;
-use Job;
 use MediaWiki\MediaWikiServices;
 
 class RottenLinksJob extends Job implements GenericParameterJob {

--- a/includes/RottenLinksJob.php
+++ b/includes/RottenLinksJob.php
@@ -75,7 +75,18 @@ class RottenLinksJob extends Job implements GenericParameterJob {
 					$url = 'https:' . $url;
 				}
 
-				$externalLinksCount = $dbw->selectRowCount( 'externallinks', 'el_to', [ 'el_to' => $url ], __METHOD__ );
+				$el = LinkFilter::makeIndexes( $url );
+				$externalLinksCount = $db->selectRowCount(
+					'externallinks',
+					[
+						'el_to_domain_index',
+						'el_to_path'
+					],
+					[
+						'el_to_domain_index' => substr( $el[0][0], 0, 255 ),
+						'el_to_path' => $el[0][1]
+					]
+				);
 				if ( $externalLinksCount > 0 ) {
 					// Don't delete if the link exists on other pages.
 					continue;

--- a/includes/RottenLinksJob.php
+++ b/includes/RottenLinksJob.php
@@ -62,6 +62,12 @@ class RottenLinksJob extends Job implements GenericParameterJob {
 				->getMaintenanceConnectionRef( DB_PRIMARY );
 
 			foreach ( $this->removedExternalLinks as $url ) {
+				$url = $this->decodeDomainName( $url );
+
+				if ( substr( $url, 0, 2 ) === '//' ) {
+					$url = 'https:' . $url;
+				}
+
 				$dbw->delete( 'rottenlinks', [ 'rl_externallink' => $url ], __METHOD__ );
 			}
 		}

--- a/includes/RottenLinksJob.php
+++ b/includes/RottenLinksJob.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\ExternalLinks\LinkFilter;
 use MediaWiki\MediaWikiServices;
 
 class RottenLinksJob extends Job implements GenericParameterJob {

--- a/includes/RottenLinksJob.php
+++ b/includes/RottenLinksJob.php
@@ -76,7 +76,7 @@ class RottenLinksJob extends Job implements GenericParameterJob {
 				}
 
 				$el = LinkFilter::makeIndexes( $url );
-				$externalLinksCount = $db->selectRowCount(
+				$externalLinksCount = $dbw->selectRowCount(
 					'externallinks',
 					'*',
 					[

--- a/includes/RottenLinksJob.php
+++ b/includes/RottenLinksJob.php
@@ -78,10 +78,7 @@ class RottenLinksJob extends Job implements GenericParameterJob {
 				$el = LinkFilter::makeIndexes( $url );
 				$externalLinksCount = $db->selectRowCount(
 					'externallinks',
-					[
-						'el_to_domain_index',
-						'el_to_path'
-					],
+					'*',
 					[
 						'el_to_domain_index' => substr( $el[0][0], 0, 255 ),
 						'el_to_path' => $el[0][1]

--- a/includes/RottenLinksPager.php
+++ b/includes/RottenLinksPager.php
@@ -47,7 +47,18 @@ class RottenLinksPager extends TablePager {
 					: HTML::element( 'font', [ 'color' => '#8B0000' ], 'No Response' );
 				break;
 			case 'rl_pageusage':
-				$pagesCount = $db->selectRowCount( 'externallinks', 'el_to', [ 'el_to' => $row->rl_externallink ] );
+				$el = LinkFilter::makeIndexes( $row->rl_externallink );
+				$pagesCount = $db->selectRowCount(
+					'externallinks',
+					[
+						'el_to_domain_index',
+						'el_to_path'
+					],
+					[
+						'el_to_domain_index' => substr( $el[0][0], 0, 255 ),
+						'el_to_path' => $el[0][1]
+					]
+				);
 				$specialLinkSearch = SpecialPage::getTitleFor( 'LinkSearch' );
 				$href = $specialLinkSearch->getInternalURL( [ 'target' => $row->rl_externallink ] );
 				$formatted = HTML::element( 'a', [ 'href' => $href ], (string)$pagesCount );

--- a/includes/RottenLinksPager.php
+++ b/includes/RottenLinksPager.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\ExternalLinks\LinkFilter;
 use MediaWiki\MediaWikiServices;
 
 class RottenLinksPager extends TablePager {

--- a/includes/RottenLinksPager.php
+++ b/includes/RottenLinksPager.php
@@ -50,10 +50,7 @@ class RottenLinksPager extends TablePager {
 				$el = LinkFilter::makeIndexes( $row->rl_externallink );
 				$pagesCount = $db->selectRowCount(
 					'externallinks',
-					[
-						'el_to_domain_index',
-						'el_to_path'
-					],
+					'*',
 					[
 						'el_to_domain_index' => substr( $el[0][0], 0, 255 ),
 						'el_to_path' => $el[0][1]

--- a/includes/SpecialRottenLinks.php
+++ b/includes/SpecialRottenLinks.php
@@ -64,22 +64,7 @@ class SpecialRottenLinks extends SpecialPage {
 			'DISTINCT'
 		);
 
-		$cache = ObjectCache::getLocalClusterInstance();
-
-		$statDescriptor = [
-			'runTime' => [
-				'type' => 'info',
-				'label-message' => 'rottenlinks-runtime',
-				'default' => $cache->get( $cache->makeKey( 'RottenLinks', 'runTime' ) ) . ' seconds',
-				'section' => 'metadata'
-			],
-			'runDate' => [
-				'type' => 'info',
-				'label-message' => 'rottenlinks-rundate',
-				'default' => $context->getLanguage()->timeanddate( $cache->get( $cache->makeKey( 'RottenLinks', 'lastRun' ) ), true ),
-				'section' => 'metadata'
-			]
-		];
+		$statDescriptor = [];
 
 		foreach ( $statusNumbers as $num ) {
 			$respCode = $num->rl_respcode;

--- a/maintenance/updateExternalLinks.php
+++ b/maintenance/updateExternalLinks.php
@@ -37,7 +37,7 @@ class UpdateExternalLinks extends Maintenance {
 			);
 
 			foreach ( $res as $row ) {
-				$elUrl = MediaWiki\ExternalLinks\LinkFilter::reverseIndexe( $row->el_to_domain_index ) . $row->el_to_path;
+				$elUrl = MediaWiki\ExternalLinks\LinkFilter::reverseIndexes( $row->el_to_domain_index ) . $row->el_to_path;
 				$rottenlinksarray[$elUrl][] = (int)$row->el_from;
 			}
 		} else {

--- a/maintenance/updateExternalLinks.php
+++ b/maintenance/updateExternalLinks.php
@@ -58,7 +58,6 @@ class UpdateExternalLinks extends Maintenance {
 				continue;
 			}
 
-
 			$rottenLinksCount = $dbw->selectRowCount( 'rottenlinks', 'rl_externallink', [ 'rl_externallink' => $url ], __METHOD__ );
 			if ( $rottenLinksCount > 0 ) {
 				// Don't create duplicate entires

--- a/maintenance/updateExternalLinks.php
+++ b/maintenance/updateExternalLinks.php
@@ -73,6 +73,8 @@ class UpdateExternalLinks extends Maintenance {
 				continue;
 			}
 
+			// This is to ensure duplicate links are not added,
+			// now that links are added after each edit that adds a url.
 			$rottenLinksCount = $dbw->selectRowCount( 'rottenlinks', 'rl_externallink', [ 'rl_externallink' => $url ], __METHOD__ );
 			if ( $rottenLinksCount > 0 ) {
 				// Don't create duplicate entires
@@ -94,10 +96,6 @@ class UpdateExternalLinks extends Maintenance {
 		}
 
 		$time = time() - $time;
-
-		$cache = ObjectCache::getLocalClusterInstance();
-		$cache->set( $cache->makeKey( 'RottenLinks', 'lastRun' ), $dbw->timestamp() );
-		$cache->set( $cache->makeKey( 'RottenLinks', 'runTime' ), $time );
 
 		$this->output( "Script took {$time} seconds.\n" );
 	}

--- a/maintenance/updateExternalLinks.php
+++ b/maintenance/updateExternalLinks.php
@@ -25,7 +25,7 @@ class UpdateExternalLinks extends Maintenance {
 			__METHOD__
 		);
 
-			$rottenlinksarray = [];
+		$rottenlinksarray = [];
 
 		if ( version_compare( MW_VERSION, '1.41', '>=' ) ) {
 			$res = $dbw->select(

--- a/maintenance/updateExternalLinks.php
+++ b/maintenance/updateExternalLinks.php
@@ -58,6 +58,13 @@ class UpdateExternalLinks extends Maintenance {
 				continue;
 			}
 
+
+			$rottenLinksCount = $dbw->selectRowCount( 'rottenlinks', 'rl_externallink', [ 'rl_externallink' => $url ], __METHOD__ );
+			if ( $rottenLinksCount > 0 ) {
+				// Don't create duplicate entires
+				continue;
+			}
+
 			$resp = RottenLinks::getResponse( $url );
 			$pagecount = count( $pages );
 

--- a/maintenance/updateExternalLinks.php
+++ b/maintenance/updateExternalLinks.php
@@ -37,7 +37,7 @@ class UpdateExternalLinks extends Maintenance {
 			);
 
 			foreach ( $res as $row ) {
-				$elUrl = MediaWiki\ExternalLinks\LinkFilter::reverseIndexes( $row->el_to_domain_index ) . $row->el_to_path;
+				$elUrl = \MediaWiki\ExternalLinks\LinkFilter::reverseIndexes( $row->el_to_domain_index ) . $row->el_to_path;
 				$rottenlinksarray[$elUrl][] = (int)$row->el_from;
 			}
 		} else {

--- a/maintenance/updateExternalLinks.php
+++ b/maintenance/updateExternalLinks.php
@@ -37,6 +37,7 @@ class UpdateExternalLinks extends Maintenance {
 			);
 
 			foreach ( $res as $row ) {
+				// @phan-suppress-next-line PhanUndeclaredStaticMethod
 				$elUrl = \MediaWiki\ExternalLinks\LinkFilter::reverseIndexes( $row->el_to_domain_index ) . $row->el_to_path;
 				$rottenlinksarray[$elUrl][] = (int)$row->el_from;
 			}

--- a/maintenance/updateExternalLinks.php
+++ b/maintenance/updateExternalLinks.php
@@ -28,14 +28,15 @@ class UpdateExternalLinks extends Maintenance {
 			'externallinks',
 			[
 				'el_from',
-				'el_to'
+				'el_to_domain_index',
+				'el_to_path'
 			]
 		);
 
 		$rottenlinksarray = [];
 
 		foreach ( $res as $row ) {
-			$rottenlinksarray[$row->el_to][] = (int)$row->el_from;
+			$rottenlinksarray[$row->el_to_domain_index . $row->el_to_path][] = (int)$row->el_from;
 		}
 
 		foreach ( $rottenlinksarray as $url => $pages ) {
@@ -63,8 +64,7 @@ class UpdateExternalLinks extends Maintenance {
 			$dbw->insert( 'rottenlinks',
 				[
 					'rl_externallink' => $url,
-					'rl_respcode' => $resp,
-					'rl_pageusage' => json_encode( $pages )
+					'rl_respcode' => $resp
 				],
 				__METHOD__
 			);

--- a/maintenance/updateExternalLinks.php
+++ b/maintenance/updateExternalLinks.php
@@ -1,6 +1,5 @@
 <?php
 
-use MediaWiki\ExternalLinks\LinkFilter;
 use MediaWiki\MediaWikiServices;
 
 require_once __DIR__ . '/../../../maintenance/Maintenance.php';
@@ -38,7 +37,7 @@ class UpdateExternalLinks extends Maintenance {
 			);
 
 			foreach ( $res as $row ) {
-				$elUrl = LinkFilter::reverseIndexe( $row->el_to_domain_index ) . $row->el_to_path;
+				$elUrl = MediaWiki\ExternalLinks\LinkFilter::reverseIndexe( $row->el_to_domain_index ) . $row->el_to_path;
 				$rottenlinksarray[$elUrl][] = (int)$row->el_from;
 			}
 		} else {

--- a/maintenance/updateExternalLinks.php
+++ b/maintenance/updateExternalLinks.php
@@ -37,7 +37,6 @@ class UpdateExternalLinks extends Maintenance {
 			);
 
 			foreach ( $res as $row ) {
-				// @phan-suppress-next-line PhanUndeclaredStaticMethod
 				$elUrl = \MediaWiki\ExternalLinks\LinkFilter::reverseIndexes( $row->el_to_domain_index ) . $row->el_to_path;
 				$rottenlinksarray[$elUrl][] = (int)$row->el_from;
 			}

--- a/maintenance/updateExternalLinks.php
+++ b/maintenance/updateExternalLinks.php
@@ -1,7 +1,7 @@
 <?php
 
-use MediaWiki\MediaWikiServices;
 use MediaWiki\ExternalLinks\LinkFilter;
+use MediaWiki\MediaWikiServices;
 
 require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 
@@ -36,7 +36,7 @@ class UpdateExternalLinks extends Maintenance {
 					'el_to_path'
 				]
 			);
-	
+
 			foreach ( $res as $row ) {
 				$elUrl = LinkFilter::reverseIndexe( $row->el_to_domain_index ) . $row->el_to_path;
 				$rottenlinksarray[$elUrl][] = (int)$row->el_from;

--- a/sql/patches/patch-drop-rl_pageusage.sql
+++ b/sql/patches/patch-drop-rl_pageusage.sql
@@ -1,0 +1,1 @@
+ALTER TABLE /*_*/rottenlinks DROP COLUMN rl_pageusage;


### PR DESCRIPTION
Instead on each page edit, we'll update the table. Rather than having to run a maintenance script.

We are too big to keep doing that and also as we grow further it'll become even more impossible because of the time it'll take.